### PR TITLE
Add autoload cookie for ELPA installation

### DIFF
--- a/org-grep.el
+++ b/org-grep.el
@@ -89,6 +89,7 @@ Each of such function is given REGEXP as an argument.")
 
 ;;; Main driver functions.
 
+;;;###autoload
 (defun org-grep (regexp &optional prefix)
   (interactive
    (list (if (use-region-p)


### PR DESCRIPTION
Hi, I plan to add this to [MELPA](http://melpa.milkbox.net/). This commit ensures that users who have installed `org-grep` from [MELPA](http://melpa.milkbox.net/) will be able to use the code without explicitly requiring the library first. For information about this fix, See [Packaging-Basics](http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging-Basics.html).
